### PR TITLE
Add the M5StickC library dependency information

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,3 +13,4 @@ platform = espressif32
 board = pico32
 framework = arduino
 upload_speed = 1500000
+lib_deps = M5StickC@0.0.5


### PR DESCRIPTION
Pinned to 0.0.5 since that's what appears to compile against (0.0.7 does not)